### PR TITLE
Default behaviour when non-existent pages are requested

### DIFF
--- a/deploy/modules/index.py
+++ b/deploy/modules/index.py
@@ -21,6 +21,13 @@ class index(object):
 
 	@exposed
 	def index(self, *args, **kwargs):
+		"""
+		The first two lines of code here ensure that requesting a non-existent module or template will throw a 404
+		instead of referring to index. Remove them if you wish to alter this behaviour.
+		"""
+		if len(args) >= 1:
+			raise errors.NotFound()
+		
 		template = self.render.getEnv().get_template("index.html")
 		return template.render(start=True)
 

--- a/deploy/modules/index.py
+++ b/deploy/modules/index.py
@@ -25,7 +25,7 @@ class index(object):
 		The first two lines of code here ensure that requesting a non-existent module or template will throw a 404
 		instead of referring to index. Remove them if you wish to alter this behaviour.
 		"""
-		if len(args) >= 1:
+		if args or kwargs:
 			raise errors.NotFound()
 		
 		template = self.render.getEnv().get_template("index.html")


### PR DESCRIPTION
Now throwing a 404 error when a path is requested that does not exist. Hopefully preventing annoying bots from bruteforcing.