### PR TITLE
Update skelview.html

### DIFF
--- a/deploy/html/macros/skelview.html
+++ b/deploy/html/macros/skelview.html
@@ -124,7 +124,7 @@ options={"keyLink": "/$(module)/view/$(key)?style=raw"}
 								{{val.descr or val|string}}{{", " if not loop.last}}
 							{% endfor %}
                         {% elif structure[step]["type"] == "bool" %}
-                            {{ _("Yes") if value else _("No") }}
+                            {{ ("Yes") if value else ("No") }}
                         {% elif structure[step]["type"] == "date" %}
                             {% if value %}
                                 {% if structure[step]["date"] and structure[step]["time"] %}


### PR DESCRIPTION
Existence of underscores raises an Internal Server Error by using the default html render and booleanBones:

```
Traceback (most recent call last):
  File "/home/klaus/coding/flightsafety/deploy/viur/core/request.py", line 221, in processRequest
    self.findAndCall(path)
  File "/home/klaus/coding/flightsafety/deploy/viur/core/request.py", line 395, in findAndCall
    res = caller(*self.args, **self.kwargs)
  File "/home/klaus/coding/flightsafety/deploy/modules/incident.py", line 13, in index
    return self.list(*args, **kwargs)
  File "/home/klaus/coding/flightsafety/deploy/viur/core/prototypes/list.py", line 170, in list
    return self.render.list(res)
  File "/home/klaus/coding/flightsafety/deploy/viur/core/render/html/default.py", line 509, in list
    return template.render(skellist=skellist, params=params, **kwargs)  # SkelListWrapper(resList, skellist)
  File "/tmp/tmpRYGA2k/lib/python3.9/site-packages/jinja2/environment.py", line 1090, in render
    self.environment.handle_exception()
  File "/tmp/tmpRYGA2k/lib/python3.9/site-packages/jinja2/environment.py", line 832, in handle_exception
    reraise(*rewrite_traceback_stack(source=source))
  File "/tmp/tmpRYGA2k/lib/python3.9/site-packages/jinja2/_compat.py", line 28, in reraise
    raise value.with_traceback(tb)
  File "html/list.html", line 2, in top-level template code
    {% from "macros/skelview.html" import SkelView %}
  File "html/viur_base.html", line 115, in top-level template code
    </header>
  File "html/list.html", line 12, in block "content"
    {{ SkelView(skel) }}
  File "/tmp/tmpRYGA2k/lib/python3.9/site-packages/jinja2/runtime.py", line 679, in _invoke
    rv = self._func(*arguments)
  File "html/macros/skelview.html", line 292, in template
    {% for bone in structures[module].keys() %}
  File "/tmp/tmpRYGA2k/lib/python3.9/site-packages/jinja2/runtime.py", line 679, in _invoke
    rv = self._func(*arguments)
  File "html/macros/skelview.html", line 127, in template
    {{ _("Yes") if value else _("No") }}
jinja2.exceptions.UndefinedError: '_' is undefined
Home
```