### PR TITLE
Update version number of google-cloud-logging.

### DIFF
--- a/deploy/requirements.txt
+++ b/deploy/requirements.txt
@@ -2,7 +2,7 @@
 safeeval==0.0.5
 
 google-cloud-datastore==1.10.0
-google-cloud-logging==1.11.0
+google-cloud-logging==2.2.0
 google-cloud-storage==1.35.1
 google-cloud-tasks==2.0.0
 google-cloud-iam==2.1.0


### PR DESCRIPTION
Hi :)

After updating viur-core to [4e5c81a5fb36e08111cb0c4deb438ca69fa601ad](https://github.com/viur-framework/viur-core/commit/4e5c81a5fb36e08111cb0c4deb438ca69fa601ad), the server raised an exception with a ModuleNotFoundError `No module named 'google.cloud.logging_v2.handlers'`

Changing the version number of google-cloud-logging to 2.2.0 fixes this problem. 2.2.0 is the latest version according to [pypi](https://pypi.org/project/google-cloud-logging/).