### PR TITLE
updated gunicorn version for OSX compatibility

### DIFF
--- a/deploy/requirements.txt
+++ b/deploy/requirements.txt
@@ -12,7 +12,7 @@ jinja2==2.11.0
 webob==1.8.6
 pillow==8.0.1
 urlfetch==1.1.3
-gunicorn==20.0
+gunicorn==20.0.4
 
 # Project requirements
 #google-cloud-kms==1.4.0


### PR DESCRIPTION
apparently gunicorn v20.0.0 is linked with libc, which is apparently not included in OSx. v20.0.4 does not produce this problem.