### PR TITLE
Add more entries to .gcloudignore

### DIFF
--- a/deploy/.gcloudignore
+++ b/deploy/.gcloudignore
@@ -1,2 +1,26 @@
-# Here you can add files to not being deployed to GAE
-viur/vi/vi/sources/node_modules
+# This file specifies files that are *not* uploaded to Google Cloud Platform
+# using gcloud. It follows the same syntax as .gitignore, with the addition of
+# "#!include" directives (which insert the entries of the given .gitignore-style
+# file at that point).
+#
+# For more information, run:
+#   $ gcloud topic gcloudignore
+#
+.gcloudignore
+# If you would like to upload your .git directory, .gitignore file or files
+# from your .gitignore file, remove the corresponding line
+# below:
+.git
+.gitignore
+
+# Python pycache:
+__pycache__/
+# Ignored by the build system
+/setup.cfg
+
+node_modules/
+/viur/docs/
+/viur/CHANGELOG.md
+/viur/LICENSE
+/viur/README.md
+/viur/.readthedocs.yml


### PR DESCRIPTION
Use generated .gcloudignore and ignore all node_modules folders and the
docs folder of the core.