### PR TITLE
Change ViUR default module importer

### DIFF
--- a/deploy/modules/__init__.py
+++ b/deploy/modules/__init__.py
@@ -24,8 +24,8 @@ for _module in os.listdir(os.path.dirname(__file__)):
 				continue
 
 			_symbol = getattr(_import, _name)
-			if (getattr(_symbol, "__module__", None) != "modules.%s" % _module
-				or isinstance(_symbol, viur.core.prototypes.basic.BasicApplication)):
+			if not (getattr(_symbol, "__module__", None) == f"modules.{_module}"
+					or isinstance(_symbol, viur.core.prototypes.basic.BasicApplication)):
 				continue
 
 			_viurModules[_name.lower()] = _symbol


### PR DESCRIPTION
Import only modules, which inherit from the `BasicApplication` and are defined in modules. No prototypes, methods or other base-types.

Resolves https://github.com/viur-framework/viur-core/issues/542