### PR TITLE
fixed error in handling multiple relationalBones in renderEditForm

### DIFF
--- a/deploy/html/editform/editform_bone_relational.html
+++ b/deploy/html/editform/editform_bone_relational.html
@@ -4,9 +4,11 @@
 		class="select ignt-select ignt-select--{{ boneName }}
 			{{ "is-required" if boneParams.required }}
 			{{ "is-readonly" if boneParams.readOnly }}
+			{{ "is-multiple" if boneParams.multiple }}
 			{{ "is-invalid" if boneWasInvalid else "is-valid" }}"
 		{{'readonly' if boneParams.readOnly}}
 		{{'required' if boneParams.required}}
+        {{'multiple' if boneParams.multiple}}
     >
 {% set ns = namespace(cursor="") %}
 {% for i in range(0, 1000, 100) %}
@@ -25,9 +27,14 @@
                 -
             </option>
         {% endif %}
-        <option value="{{ entry["key"] }}" {{ "selected" if boneValue and entry["key"] == boneValue["dest"]["key"] }}>
-            {{ entry["name"] }}
-        </option>
+            <option value="{{ entry["key"] }}"
+                    {% if boneParams.multiple %}
+                        {{ "selected" if entry["key"] in boneValue|map(attribute='dest.key') }}
+                    {% else %}
+                        {{ "selected" if boneValue and boneValue['dest'] and entry["key"] == boneValue["dest"]["key"] }}
+                    {% endif %}>
+                {{ entry["name"] }}
+            </option>
     {% endfor %}
 {% endfor %}
 

--- a/deploy/html/editform/editform_row.html
+++ b/deploy/html/editform/editform_row.html
@@ -4,6 +4,7 @@
 			class="label ignt-label
 				{{ "is-required" if boneParams.required }}
 				{{ "is-readonly" if boneParams.readOnly }}
+				{{ "is-multiple" if boneParams.multiple }}
 				{{ "is-invalid" if boneErrors else "is-valid" }}"
 		>
 			{{ boneParams.descr }}


### PR DESCRIPTION
There was an error in handling multiple relationalBones in the standart renderEditForm(skel)-function with jinja.

The template expects a dict, but the multiple relationalBone returns a list of the selected values which results in an error.
The template now checks, if the boneParam multiple is set and then iterate over the list of the selected values. 
Otherwise it behaves as before.