### PR TITLE
fix: Add missing index for `File` queryIter

### DIFF
--- a/deploy/index.yaml
+++ b/deploy/index.yaml
@@ -10,6 +10,11 @@ indexes:
   - name: parententry
   - name: sortindex
 
+- kind: file
+  properties:
+  - name: pending
+  - name: creationdate
+
 - kind: file_rootNode
   properties:
   - name: parententry


### PR DESCRIPTION
This index is missing with viur-core 3.5