### PR TITLE
feat: Add app_engine_apis to the app.yml

### DIFF
--- a/deploy/app.yaml
+++ b/deploy/app.yaml
@@ -45,6 +45,8 @@ handlers:
 - url: /robots.txt
   static_files: static/meta/robots.txt
   upload: robots.txt
+# (5) This is necessary to use the Google appengine apis
+app_engine_apis: true
 
 inbound_services:
 - warmup


### PR DESCRIPTION
Necessary for https://github.com/viur-framework/viur-core/pull/830 and https://github.com/viur-framework/viur-datastore/pull/30