### PR TITLE
feat: Improved `__init__.py` for `skeletons` and `modules`

### DIFF
--- a/deploy/skeletons/__init__.py
+++ b/deploy/skeletons/__init__.py
@@ -1,13 +1,28 @@
-# This is the ViUR default skeleton importer;
-# If any other importing logic is wanted, please switch to manual import calls in this file, and remove
-# the dynamic code provided below.
-
 import os
+import importlib
 
-for skelModule in os.listdir(os.path.dirname(__file__)):
-    if skelModule == "__init__.py" or not skelModule.endswith(".py"):
-        continue
 
-    __import__(skelModule[:-3], globals(), locals(), level=1)
+def import_submodules(package_dir, package_name):
+    """
+    Recursively imports all modules in the given package directory.
 
-del skelModule
+    :param package_dir: Path to the directory of the package
+    :param package_name: Name of the package
+    """
+    for entry in os.listdir(package_dir):
+        entry_path = os.path.join(package_dir, entry)
+        if os.path.isdir(entry_path) and os.path.exists(os.path.join(entry_path, "__init__.py")):
+            # Recursively import subpackages
+            import_submodules(entry_path, f"{package_name}.{entry}")
+        elif entry.endswith(".py") and entry != "__init__.py":
+            # Import the module
+            module_name = entry[:-3]  # Remove the .py extension
+            importlib.import_module(f"{package_name}.{module_name}")
+
+
+# Set the base directory and package name
+base_dir = os.path.dirname(__file__)
+base_package = os.path.basename(base_dir)
+
+# Import all submodules recursively
+import_submodules(base_dir, base_package)


### PR DESCRIPTION
This PR changes the current `__init__.py`-scripts to allow for module- and skeleton restructuring using folders.

- `skeletons/__init__.py` imports skeletons from any sub-folders now
- `modules/__init__.py` imports modules from any sub-folder, but registers them as they where defined just in modules, so there's no prefixing like before.

As the latter one "breaks" a current behavior, IMHO this was only requested for the viur-shop module and was solved differently there, as there is a `Shop()`-module which is imported.